### PR TITLE
исправлена синтаксическая ошибка для ENV-переменных датанод

### DIFF
--- a/Hadoop/hadoop-compose.yaml
+++ b/Hadoop/hadoop-compose.yaml
@@ -53,7 +53,7 @@ services:
     hostname: datanode1
     environment:
       - CORE_CONF_fs_defaultFS=hdfs://namenode:9000
-      - HDFS_CONF_dfs.client.use.datanode.hostname=false
+      - HDFS_CONF_dfs__client__use__datanode__hostname=false
     ports:
       - "9864:9864"
     volumes:
@@ -68,7 +68,7 @@ services:
     hostname: datanode2
     environment:
       - CORE_CONF_fs_defaultFS=hdfs://namenode:9000
-      - HDFS_CONF_dfs.client.use.datanode.hostname=false
+      - HDFS_CONF_dfs__client__use__datanode__hostname=false
     volumes:
       - datanode2-data:/hadoop/dfs/data
     depends_on:


### PR DESCRIPTION
Анализируя результат логов датанод, была выявлена некритическая ошибка: «/entrypoint.sh: line 28: HDFS_CONF_dfs.client.use.datanode.hostname: bad substitution». Ошибка чисто синтаксическая, из-за неправильно заданного поля конфига докера. Надо изменить в каждом датаконтейнере поле 
`HDFS_CONF_dfs.client.use.datanode.hostname=false`
на
`HDFS_CONF_dfs__client__use__datanode__hostname=false`

Возможно, именно данная ошибка способствовала крашу java на namenode после выполнения python-тестов. Сами тесты выполняются корректно, но после 
После исправления конфига, ошибка исчезла и неймнода более не крашилась.